### PR TITLE
Restore interactive editing for defaults and bands

### DIFF
--- a/pages/bandas_indicador.py
+++ b/pages/bandas_indicador.py
@@ -1,7 +1,12 @@
-import yaml
-from pathlib import Path
 import streamlit as st
 from utils import show_logo
+from segmentacion_base import (
+    DEFAULT_PLUM_RULES,
+    DEFAULT_NECT_RULES,
+    plum_rules_to_df,
+    nect_rules_to_df,
+)
+
 
 st.set_page_config(page_title="Bandas por indicador", page_icon="🎯", layout="wide")
 
@@ -42,27 +47,30 @@ def generar_menu():
 def main():
     generar_menu()
     st.title("Bandas por indicador")
-    path = Path("bandas.yaml")
-    if "bandas" not in st.session_state:
-        if path.exists():
-            st.session_state["bandas"] = yaml.safe_load(path.read_text()) or {}
-        else:
-            st.session_state["bandas"] = {}
-    data = st.session_state["bandas"]
-    text = st.text_area(
-        "Editar bandas (YAML)",
-        yaml.safe_dump(data, allow_unicode=True, sort_keys=False),
-        height=300,
-    )
-    if st.button("Guardar"):
-        try:
-            parsed = yaml.safe_load(text) or {}
-            st.session_state["bandas"] = parsed
-            path.write_text(yaml.safe_dump(parsed, allow_unicode=True, sort_keys=False))
-            st.success("Bandas guardadas en bandas.yaml")
-        except yaml.YAMLError as e:
-            st.error(f"YAML inválido: {e}")
+
+    # Inicializar dataframes de reglas
+    if "plum_rules_df" not in st.session_state:
+        st.session_state["plum_rules_df"] = plum_rules_to_df(DEFAULT_PLUM_RULES)
+    if "nect_rules_df" not in st.session_state:
+        st.session_state["nect_rules_df"] = nect_rules_to_df(DEFAULT_NECT_RULES)
+
+    especie = st.radio("Especie", ["Ciruela", "Nectarina"], horizontal=True)
+    if especie == "Ciruela":
+        st.session_state["plum_rules_df"] = st.data_editor(
+            st.session_state["plum_rules_df"],
+            num_rows="dynamic",
+            key="plum_rules_editor",
+        )
+    else:
+        st.session_state["nect_rules_df"] = st.data_editor(
+            st.session_state["nect_rules_df"],
+            num_rows="dynamic",
+            key="nect_rules_editor",
+        )
+
+    st.info("Los cambios se guardan automáticamente en la sesión.")
 
 
 if __name__ == "__main__":
     main()
+

--- a/pages/default_values.py
+++ b/pages/default_values.py
@@ -1,7 +1,6 @@
-import json
-from pathlib import Path
 import streamlit as st
 from utils import show_logo
+
 
 st.set_page_config(page_title="Valores por defecto", page_icon="⚙️", layout="wide")
 
@@ -42,27 +41,50 @@ def generar_menu():
 def main():
     generar_menu()
     st.title("Valores por defecto")
-    path = Path("defaults.json")
-    if "default_values" not in st.session_state:
-        if path.exists():
-            st.session_state["default_values"] = json.loads(path.read_text())
-        else:
-            st.session_state["default_values"] = {}
-    data = st.session_state["default_values"]
-    text = st.text_area(
-        "Editar valores (JSON)",
-        json.dumps(data, indent=2, ensure_ascii=False),
-        height=300,
+
+    # Inicializar valores en la sesión
+    if "default_plum_subtype" not in st.session_state:
+        st.session_state["default_plum_subtype"] = "sugar"
+    if "sugar_upper" not in st.session_state:
+        st.session_state["sugar_upper"] = 60.0
+    if "default_color" not in st.session_state:
+        st.session_state["default_color"] = "Amarilla"
+    if "default_period" not in st.session_state:
+        st.session_state["default_period"] = "tardia"
+
+    st.header("Ciruela")
+    st.selectbox(
+        "Tipo de ciruela por defecto si el peso no está disponible",
+        options=["sugar", "candy"],
+        index=["sugar", "candy"].index(st.session_state["default_plum_subtype"]),
+        key="default_plum_subtype",
     )
-    if st.button("Guardar"):
-        try:
-            parsed = json.loads(text)
-            st.session_state["default_values"] = parsed
-            path.write_text(json.dumps(parsed, indent=2, ensure_ascii=False))
-            st.success("Valores guardados en defaults.json")
-        except json.JSONDecodeError as e:
-            st.error(f"JSON inválido: {e}")
+    st.number_input(
+        "Peso máximo para sugar (g)",
+        min_value=10.0,
+        max_value=200.0,
+        value=float(st.session_state["sugar_upper"]),
+        step=1.0,
+        key="sugar_upper",
+    )
+
+    st.header("Nectarina")
+    st.selectbox(
+        "Color de pulpa por defecto (si falta)",
+        options=["Amarilla", "Blanca"],
+        index=["Amarilla", "Blanca"].index(st.session_state["default_color"]),
+        key="default_color",
+    )
+    st.selectbox(
+        "Periodo de cosecha por defecto (si falta fecha)",
+        options=["muy_temprana", "temprana", "tardia", "sin_fecha"],
+        index=["muy_temprana", "temprana", "tardia", "sin_fecha"].index(st.session_state["default_period"]),
+        key="default_period",
+    )
+
+    st.success("Los valores se guardan automáticamente en la sesión.")
 
 
 if __name__ == "__main__":
     main()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ openpyxl
 altair
 xlsxwriter
 jinja2
-pyyaml


### PR DESCRIPTION
## Summary
- Replace JSON/YAML editors with interactive Streamlit widgets for default values and indicator bands
- Drop unused PyYAML dependency

## Testing
- `python -m py_compile pages/default_values.py pages/bandas_indicador.py`


------
https://chatgpt.com/codex/tasks/task_b_68acb6bbcaf88330b3fe6a881d0578db